### PR TITLE
google_assistant: add require_acknowledgment option for secure commands

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -22,6 +22,7 @@ from .const import (  # noqa: F401
     CONF_PRIVATE_KEY,
     CONF_PROJECT_ID,
     CONF_REPORT_STATE,
+    CONF_REQUIRE_ACK,
     CONF_ROOM_HINT,
     CONF_SECURE_DEVICES_PIN,
     CONF_SERVICE_ACCOUNT,
@@ -49,6 +50,7 @@ ENTITY_SCHEMA = vol.Schema(
         vol.Optional(CONF_EXPOSE, default=True): cv.boolean,
         vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_ROOM_HINT): cv.string,
+        vol.Optional(CONF_REQUIRE_ACK, default=False): cv.boolean,
     }
 )
 

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -44,6 +44,7 @@ CONF_REPORT_STATE = "report_state"
 CONF_ROOM_HINT = "room"
 CONF_SECURE_DEVICES_PIN = "secure_devices_pin"
 CONF_SERVICE_ACCOUNT = "service_account"
+CONF_REQUIRE_ACK = "require_acknowledgment"
 
 DATA_CONFIG = "config"
 

--- a/homeassistant/components/google_assistant/error.py
+++ b/homeassistant/components/google_assistant/error.py
@@ -1,6 +1,6 @@
 """Errors for Google Assistant."""
 
-from .const import ERR_CHALLENGE_NEEDED
+from .const import CHALLENGE_ACK_NEEDED, CHALLENGE_PIN_NEEDED, ERR_CHALLENGE_NEEDED
 
 
 class SmartHomeError(Exception):
@@ -25,9 +25,17 @@ class ChallengeNeeded(SmartHomeError):
     https://developers.google.com/actions/smarthome/create-app#error_responses
     """
 
-    def __init__(self, challenge_type):
+    def __init__(self, ack_needed=False, pin_needed=False, challenge_type=None):
         """Initialize challenge needed error."""
-        super().__init__(ERR_CHALLENGE_NEEDED, f"Challenge needed: {challenge_type}")
+        super().__init__(ERR_CHALLENGE_NEEDED, "Challenge needed")
+        self.ack_needed = ack_needed
+        self.pin_needed = pin_needed
+        # Auto-set challenge_type based on flags if not explicitly provided
+        if challenge_type is None:
+            if pin_needed:
+                challenge_type = CHALLENGE_PIN_NEEDED
+            elif ack_needed:
+                challenge_type = CHALLENGE_ACK_NEEDED
         self.challenge_type = challenge_type
 
     def to_response(self):

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -90,7 +90,7 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
     CHALLENGE_FAILED_PIN_NEEDED,
-    CHALLENGE_PIN_NEEDED,
+    CONF_REQUIRE_ACK,
     ERR_ALREADY_ARMED,
     ERR_ALREADY_DISARMED,
     ERR_ALREADY_STOPPED,
@@ -291,6 +291,14 @@ class _Trait(ABC):
         self.state = state
         self.config = config
 
+    def check_ack(self, challenge):
+        """Verify if acknowledgment is required and present."""
+        entity_config = self.config.entity_config.get(self.state.entity_id, {})
+        if entity_config.get(CONF_REQUIRE_ACK):
+            ack_ok = isinstance(challenge, dict) and challenge.get("ack") is True
+            if not ack_ok:
+                raise ChallengeNeeded(ack_needed=True)
+
     def sync_attributes(self) -> dict[str, Any]:
         """Return attributes for a sync request."""
         raise NotImplementedError
@@ -352,6 +360,9 @@ class BrightnessTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a brightness command."""
+
+        self.check_ack(challenge)
+
         if self.state.domain == light.DOMAIN:
             await self.hass.services.async_call(
                 light.DOMAIN,
@@ -507,6 +518,9 @@ class OnOffTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute an OnOff command."""
+
+        self.check_ack(challenge)
+
         if (domain := self.state.domain) == group.DOMAIN:
             service_domain = HOMEASSISTANT_DOMAIN
             service = SERVICE_TURN_ON if params["on"] else SERVICE_TURN_OFF
@@ -599,6 +613,9 @@ class ColorSettingTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a color temperature command."""
+
+        self.check_ack(challenge)
+
         if "temperature" in params["color"]:
             temp = params["color"]["temperature"]
             max_temp = self.state.attributes[light.ATTR_MAX_COLOR_TEMP_KELVIN]
@@ -685,6 +702,9 @@ class SceneTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a scene command."""
+
+        self.check_ack(challenge)
+
         service = SERVICE_TURN_ON
         if self.state.domain == button.DOMAIN:
             service = button.SERVICE_PRESS
@@ -734,6 +754,9 @@ class DockTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a dock command."""
+
+        self.check_ack(challenge)
+
         domain = self.state.domain
         service: str | None = None
 
@@ -777,6 +800,9 @@ class LocatorTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a locate command."""
+
+        self.check_ack(challenge)
+
         if params.get("silence", False):
             raise SmartHomeError(
                 ERR_FUNCTION_NOT_SUPPORTED,
@@ -929,6 +955,9 @@ class StartStopTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a StartStop command."""
+
+        self.check_ack(challenge)
+
         domain = self.state.domain
         if domain == vacuum.DOMAIN:
             await self._execute_vacuum(command, data, params, challenge)
@@ -1142,6 +1171,9 @@ class TemperatureControlTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a temperature point or mode command."""
+
+        self.check_ack(challenge)
+
         # All sent in temperatures are always in Celsius
         domain = self.state.domain
         unit = self.hass.config.units.temperature_unit
@@ -1334,6 +1366,9 @@ class TemperatureSettingTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a temperature point or mode command."""
+
+        self.check_ack(challenge)
+
         # All sent in temperatures are always in Celsius
         unit = self.hass.config.units.temperature_unit
         min_temp = self.state.attributes[climate.ATTR_MIN_TEMP]
@@ -1530,6 +1565,9 @@ class HumiditySettingTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a humidity command."""
+
+        self.check_ack(challenge)
+
         if self.state.domain == sensor.DOMAIN:
             raise SmartHomeError(
                 ERR_NOT_SUPPORTED, "Execute is not supported by sensor"
@@ -1582,6 +1620,9 @@ class LockUnlockTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute an LockUnlock command."""
+
+        self.check_ack(challenge)
+
         if params["lock"]:
             service = lock.SERVICE_LOCK
         else:
@@ -1687,6 +1728,9 @@ class ArmDisArmTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute an ArmDisarm command."""
+
+        self.check_ack(challenge)
+
         if params["arm"] and not params.get("cancel"):
             # If no arm level given, we we arm the first supported
             # level in state_to_support.
@@ -1897,6 +1941,9 @@ class FanSpeedTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a smart home command."""
+
+        self.check_ack(challenge)
+
         if command == COMMAND_SET_FAN_SPEED:
             await self.execute_fanspeed(data, params)
         elif command == COMMAND_REVERSE:
@@ -2031,6 +2078,9 @@ class ModesTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a SetModes command."""
+
+        self.check_ack(challenge)
+
         settings = params.get("updateModeSettings")
 
         if self.state.domain == fan.DOMAIN:
@@ -2178,6 +2228,9 @@ class InputSelectorTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute an SetInputSource command."""
+
+        self.check_ack(challenge)
+
         sources = self.state.attributes.get(media_player.ATTR_INPUT_SOURCE_LIST) or []
         source = self.state.attributes.get(media_player.ATTR_INPUT_SOURCE)
 
@@ -2314,6 +2367,9 @@ class OpenCloseTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute an Open, close, Set position command."""
+
+        self.check_ack(challenge)
+
         domain = self.state.domain
         features = self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
@@ -2490,6 +2546,9 @@ class VolumeTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a volume command."""
+
+        self.check_ack(challenge)
+
         if command == COMMAND_SET_VOLUME:
             await self._execute_set_volume(data, params)
         elif command == COMMAND_VOLUME_RELATIVE:
@@ -2508,10 +2567,13 @@ def _verify_pin_challenge(data, state, challenge):
         raise SmartHomeError(ERR_CHALLENGE_NOT_SETUP, "Challenge is not set up")
 
     if not challenge:
-        raise ChallengeNeeded(CHALLENGE_PIN_NEEDED)
+        raise ChallengeNeeded(pin_needed=True)
 
     if challenge.get("pin") != data.config.secure_devices_pin:
-        raise ChallengeNeeded(CHALLENGE_FAILED_PIN_NEEDED)
+        # Pass pin_needed=True and specify the challenge type for input error
+        raise ChallengeNeeded(
+            pin_needed=True, challenge_type=CHALLENGE_FAILED_PIN_NEEDED
+        )
 
 
 MEDIA_COMMAND_SUPPORT_MAPPING = {
@@ -2587,6 +2649,9 @@ class TransportControlTrait(_Trait):
 
     async def execute(self, command, data, params, challenge):
         """Execute a media command."""
+
+        self.check_ack(challenge)
+
         service_attrs = {ATTR_ENTITY_ID: self.state.entity_id}
 
         if command == COMMAND_MEDIA_SEEK_RELATIVE:

--- a/tests/components/google_assistant/test_require_acknowledgment.py
+++ b/tests/components/google_assistant/test_require_acknowledgment.py
@@ -1,0 +1,287 @@
+"""Tests for the require_acknowledgment feature in Google Assistant traits."""
+
+import pytest
+
+from homeassistant.components import light, lock, switch
+from homeassistant.components.google_assistant import const, error, helpers, trait
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant, State
+
+from . import BASIC_CONFIG, MockConfig
+
+from tests.common import async_mock_service
+
+ACK_CONFIG = MockConfig(
+    entity_config={
+        "light.dimmer": {const.CONF_REQUIRE_ACK: True},
+        "switch.test": {const.CONF_REQUIRE_ACK: True},
+        "lock.door": {const.CONF_REQUIRE_ACK: True},
+    }
+)
+
+ACK_DATA = helpers.RequestData(
+    ACK_CONFIG,
+    "test-agent",
+    const.SOURCE_CLOUD,
+    "ff36a3cc-ec34-11e6-b1a0-64510650abcf",
+    None,
+)
+
+
+async def test_brightness_require_acknowledgment(hass: HomeAssistant) -> None:
+    """Test BrightnessTrait with require_acknowledgment enabled."""
+    trt = trait.BrightnessTrait(
+        hass,
+        State("light.dimmer", light.STATE_ON, {light.ATTR_BRIGHTNESS: 243}),
+        ACK_CONFIG,
+    )
+
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+
+    # No challenge data - should raise ChallengeNeeded with ack_needed=True
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_BRIGHTNESS_ABSOLUTE, ACK_DATA, {"brightness": 50}, {}
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.ack_needed is True
+    assert err.value.challenge_type == const.CHALLENGE_ACK_NEEDED
+
+    # With acknowledgment data - should execute successfully
+    await trt.execute(
+        trait.COMMAND_BRIGHTNESS_ABSOLUTE,
+        ACK_DATA,
+        {"brightness": 50},
+        {"ack": True},
+    )
+    assert len(calls) == 1
+    assert calls[0].data == {
+        ATTR_ENTITY_ID: "light.dimmer",
+        light.ATTR_BRIGHTNESS_PCT: 50,
+    }
+
+
+async def test_onoff_require_acknowledgment(hass: HomeAssistant) -> None:
+    """Test OnOffTrait with require_acknowledgment enabled."""
+    trt = trait.OnOffTrait(
+        hass,
+        State("switch.test", "on"),
+        ACK_CONFIG,
+    )
+
+    calls = async_mock_service(hass, switch.DOMAIN, "turn_off")
+
+    # No challenge data - should raise ChallengeNeeded with ack_needed=True
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(trait.COMMAND_ON_OFF, ACK_DATA, {"on": False}, {})
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.ack_needed is True
+    assert err.value.challenge_type == const.CHALLENGE_ACK_NEEDED
+
+    # With acknowledgment data - should execute successfully
+    await trt.execute(
+        trait.COMMAND_ON_OFF,
+        ACK_DATA,
+        {"on": False},
+        {"ack": True},
+    )
+    assert len(calls) == 1
+
+
+async def test_lockunlock_require_acknowledgment(hass: HomeAssistant) -> None:
+    """Test LockUnlockTrait with require_acknowledgment enabled."""
+    trt = trait.LockUnlockTrait(
+        hass,
+        State("lock.door", lock.LockState.UNLOCKED),
+        ACK_CONFIG,
+    )
+
+    calls = async_mock_service(hass, lock.DOMAIN, lock.SERVICE_LOCK)
+
+    # No challenge data - should raise ChallengeNeeded with ack_needed=True
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(trait.COMMAND_LOCK_UNLOCK, ACK_DATA, {"lock": True}, {})
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.ack_needed is True
+    assert err.value.challenge_type == const.CHALLENGE_ACK_NEEDED
+
+    # With acknowledgment data - should execute successfully
+    await trt.execute(
+        trait.COMMAND_LOCK_UNLOCK,
+        ACK_DATA,
+        {"lock": True},
+        {"ack": True},
+    )
+    assert len(calls) == 1
+
+
+async def test_require_acknowledgment_disabled(hass: HomeAssistant) -> None:
+    """Test that commands execute normally when require_acknowledgment is not set."""
+    trt = trait.OnOffTrait(
+        hass,
+        State("switch.test", "on"),
+        BASIC_CONFIG,
+    )
+
+    calls = async_mock_service(hass, switch.DOMAIN, "turn_off")
+
+    # Without require_acknowledgment, command should execute without challenge
+    basic_data = helpers.RequestData(
+        BASIC_CONFIG,
+        "test-agent",
+        const.SOURCE_CLOUD,
+        "ff36a3cc-ec34-11e6-b1a0-64510650abcf",
+        None,
+    )
+    await trt.execute(trait.COMMAND_ON_OFF, basic_data, {"on": False}, {})
+
+    assert len(calls) == 1
+
+
+# Tests for PIN + acknowledgment interaction
+
+PIN_AND_ACK_CONFIG = MockConfig(
+    secure_devices_pin="1234",
+    entity_config={
+        "lock.secure_door": {const.CONF_REQUIRE_ACK: True},
+    },
+)
+
+PIN_AND_ACK_DATA = helpers.RequestData(
+    PIN_AND_ACK_CONFIG,
+    "test-agent",
+    const.SOURCE_CLOUD,
+    "ff36a3cc-ec34-11e6-b1a0-64510650abcf",
+    None,
+)
+
+
+async def test_pin_and_ack_both_required_unlock(hass: HomeAssistant) -> None:
+    """Test unlock command when both PIN and acknowledgment are required.
+
+    The ack check should run first before PIN verification.
+    """
+    trt = trait.LockUnlockTrait(
+        hass,
+        State("lock.secure_door", lock.LockState.LOCKED),
+        PIN_AND_ACK_CONFIG,
+    )
+
+    calls = async_mock_service(hass, lock.DOMAIN, lock.SERVICE_UNLOCK)
+
+    # No challenge - should request acknowledgment first
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_LOCK_UNLOCK, PIN_AND_ACK_DATA, {"lock": False}, {}
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.ack_needed is True
+    assert err.value.challenge_type == const.CHALLENGE_ACK_NEEDED
+
+    # With ack but no PIN - should now request PIN (failed attempt since ack dict provided)
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_LOCK_UNLOCK,
+            PIN_AND_ACK_DATA,
+            {"lock": False},
+            {"ack": True},
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.pin_needed is True
+    # Since we provided a challenge dict (ack), missing PIN is treated as failed PIN
+    assert err.value.challenge_type == const.CHALLENGE_FAILED_PIN_NEEDED
+
+    # With ack and valid PIN - should succeed
+    await trt.execute(
+        trait.COMMAND_LOCK_UNLOCK,
+        PIN_AND_ACK_DATA,
+        {"lock": False},
+        {"ack": True, "pin": "1234"},
+    )
+    assert len(calls) == 1
+    assert calls[0].data == {ATTR_ENTITY_ID: "lock.secure_door"}
+
+
+async def test_ack_bypass_attempts(hass: HomeAssistant) -> None:
+    """Test that various ack bypass attempts fail when ack is required."""
+    trt = trait.OnOffTrait(
+        hass,
+        State("switch.test", "on"),
+        ACK_CONFIG,
+    )
+
+    calls = async_mock_service(hass, switch.DOMAIN, "turn_off")
+
+    # Test ack=false should fail
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(trait.COMMAND_ON_OFF, ACK_DATA, {"on": False}, {"ack": False})
+    assert len(calls) == 0
+    assert err.value.ack_needed is True
+
+    # Test ack=None should fail
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(trait.COMMAND_ON_OFF, ACK_DATA, {"on": False}, {"ack": None})
+    assert len(calls) == 0
+    assert err.value.ack_needed is True
+
+    # Test only PIN (no ack) should fail when ack is required
+    pin_only_config = MockConfig(
+        secure_devices_pin="1234",
+        entity_config={"lock.door": {const.CONF_REQUIRE_ACK: True}},
+    )
+    pin_only_data = helpers.RequestData(
+        pin_only_config,
+        "test-agent",
+        const.SOURCE_CLOUD,
+        "ff36a3cc-ec34-11e6-b1a0-64510650abcf",
+        None,
+    )
+
+    trt_lock = trait.LockUnlockTrait(
+        hass,
+        State("lock.door", lock.LockState.LOCKED),
+        pin_only_config,
+    )
+
+    lock_calls = async_mock_service(hass, lock.DOMAIN, lock.SERVICE_UNLOCK)
+
+    # PIN without ack should fail ack check first
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt_lock.execute(
+            trait.COMMAND_LOCK_UNLOCK,
+            pin_only_data,
+            {"lock": False},
+            {"pin": "1234"},  # Valid PIN but no ack
+        )
+    assert len(lock_calls) == 0
+    assert err.value.ack_needed is True
+    assert err.value.challenge_type == const.CHALLENGE_ACK_NEEDED
+
+
+async def test_unlock_with_invalid_pin_after_ack(hass: HomeAssistant) -> None:
+    """Test that invalid PIN is caught after valid ack is provided."""
+    trt = trait.LockUnlockTrait(
+        hass,
+        State("lock.secure_door", lock.LockState.LOCKED),
+        PIN_AND_ACK_CONFIG,
+    )
+
+    calls = async_mock_service(hass, lock.DOMAIN, lock.SERVICE_UNLOCK)
+
+    # With ack but wrong PIN - should fail PIN challenge
+    with pytest.raises(error.ChallengeNeeded) as err:
+        await trt.execute(
+            trait.COMMAND_LOCK_UNLOCK,
+            PIN_AND_ACK_DATA,
+            {"lock": False},
+            {"ack": True, "pin": "9999"},
+        )
+    assert len(calls) == 0
+    assert err.value.code == const.ERR_CHALLENGE_NEEDED
+    assert err.value.pin_needed is True
+    assert err.value.challenge_type == const.CHALLENGE_FAILED_PIN_NEEDED


### PR DESCRIPTION
## Proposed change

This PR adds a `require_acknowledgment` configuration option for Google Assistant entities, allowing users to require voice confirmation before executing sensitive commands.

**Key Features:**
- Per-entity `require_acknowledgment` option (YAML configuration)
- Uses Google's native acknowledgment challenge (`ackNeeded`)
- Works seamlessly with existing `secure_devices_pin` configuration
- Fully backward compatible - disabled by default
- Follows the existing YAML-only configuration pattern of the Google Assistant integration

**Use Case:**
Users can protect sensitive devices (locks, garage doors, security systems) by requiring an explicit "Yes" confirmation before commands execute, without the complexity of PIN codes.

**Example Configuration:**
```yaml
google_assistant:
  project_id: my-project-id
  service_account: !include SERVICE_ACCOUNT.json
  entity_config:
    lock.front_door:
      expose: true
      require_acknowledgment: true
```

**User Experience:**
- Command: *"Hey Google, unlock the front door"*
- Google: *"Are you sure?"*
- User: *"Yes"*
- Action executes

This follows the integration's existing pattern of YAML-only entity configuration (like `room`, `aliases`, `name`), making it consistent with current architecture.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
